### PR TITLE
Fixed: Failed to load snippets (Duplicate key error)

### DIFF
--- a/snippets/element-ui-form.cson
+++ b/snippets/element-ui-form.cson
@@ -274,7 +274,7 @@
     'body': """
     <el-rate v-model="$1"></el-rate>
     """
-  'Vue element ui el-rate':
+  'Vue element ui el-rate with icon':
     'prefix': 'efrti',
     'body': """
     <el-rate


### PR DESCRIPTION
Resolves https://github.com/solobat/vue-element-ui-snippets/issues/3

This has been bugging me for a while, thought I'd fix it myself.

Otherwise great package!